### PR TITLE
Add ZSH framework support

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -41,21 +41,23 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
         with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
+          # Full git history is needed to get a proper list of changed files
+          # within `mega-linter`
           fetch-depth: 0
 
       ################################
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: nvuillam/mega-linter@v5
+        uses: megalinter/megalinter@v6
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISABLE_LINTERS: SPELL_CSPELL
+          DISABLE_LINTERS: SPELL_CSPELL,SPELL_PROSELINT
 
-      # Upload Mega-Linter artifacts. They will be available on Github action page "Artifacts" section
+      # Upload Mega-Linter artifacts.
+      # They will be available on Github action page "Artifacts" section
       - name: Archive production artifacts
         if: ${{ success() }} || ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -25,3 +25,27 @@ Collected snippets and scripts from the commandline-fu channel on coffeeops slac
 
 - [git-extra-commands](https://github.com/unixorn/git-extra-commands) - Collected extra `git` commands
 - [tumult](https://github.com/unixorn/tumult.plugin.zsh) - macOS-specific scripts. They're packaged as a ZSH plugin but can easily be used with other shells.
+
+## Installing
+
+The commandline-fu collection is packaged as a ZSH plugin to make it easier to use if you're already using a ZSH framework. If you don't already use a framework, I recommend [Zgenom](https://github.com/jandamm/zgenom), because it is wicked fast and also supports using [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)'s internal plugins.
+
+### Bash / not using a framework
+
+If you're using `bash`, or aren't using a framework, you can install it by cloning this repository and adding its bin directory to your `$PATH`.
+
+### [Antigen](https://github.com/zsh-users/antigen)
+
+Add `antigen bundle unixorn/tumult.plugin.zsh` to your `.zshrc` with your other bundle commands.
+
+Antigen will handle cloning the plugin for you automatically the next time you start `zsh`. You can also add the plugin to a running ZSH with `antigen bundle CoffeeOps/commandline-fu` for testing before adding it to your `.zshrc`.
+
+### [Oh-My-Zsh](http://ohmyz.sh/)
+
+1. `cd ~/.oh-my-zsh/custom/plugins`
+2. `git clone git@github.com:CoffeeOps/commandline-fu.git commandlinefu`
+3. Add tumult to your plugin list - edit `~/.zshrc` and change `plugins=(...)` to `plugins=(... commandlinefu)`
+
+### [Zgenom](https://github.com/jandamm/zgenom)
+
+Add `zgenom load CoffeeOps/commandline-fu` to your `.zshrc` file in the same function you're doing your other `zgenom load` calls in. Zgenom will handle automatically cloning the plugin for you the next time you do a `zgenom save`.

--- a/commandline-fu.plugin.zsh
+++ b/commandline-fu.plugin.zsh
@@ -1,0 +1,24 @@
+# Copyright 2022 Joseph Block <jpb@unixorn.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# All of this stuff is macOS-specific, so if we're not on Darwin, bail out
+# gracefully.
+#
+# This makes it easier to use the same plugin list on both Linux and macOS
+# without polluting your Linux environment with functions and files that
+# will fail.
+
+# Add our plugin's bin directory to user's path
+PLUGIN_BIN="$(dirname $0)/bin"
+export PATH=${PATH}:${PLUGIN_BIN}


### PR DESCRIPTION
# Description

- Make it easier to add the commandline-fu scripts for ZSH framework users by adding an [oh-my-zsh](https://ohmyz.sh)-compatible plugin file.
- Add installation directions for `bash` and some of the more popular ZSH frameworks.
- Update mega-linter GitHub action to v6

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [x] Test updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
